### PR TITLE
Hotfix/license

### DIFF
--- a/MouseHandler/Assets/Assambra/Game Framework/Modules/MouseHandler/LICENSE
+++ b/MouseHandler/Assets/Assambra/Game Framework/Modules/MouseHandler/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Philipp Leutner (Assambra)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/MouseHandler/Assets/Assambra/Game Framework/Modules/MouseHandler/LICENSE.meta
+++ b/MouseHandler/Assets/Assambra/Game Framework/Modules/MouseHandler/LICENSE.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ad98fc6b64b32e9499ecb4595a26225c
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MouseHandler/ProjectSettings/ProjectSettings.asset
+++ b/MouseHandler/ProjectSettings/ProjectSettings.asset
@@ -134,7 +134,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 1.0.0
+  bundleVersion: 1.0.1
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0


### PR DESCRIPTION
Added a copy of the LICENSE into the "Assets/Assambra/Game Framework/Modules/MouseHandler/" folder. So that it is aviable in the Unity asset pack and the Unity project it self.